### PR TITLE
Fix #5 : remove array in json response when there is only one value

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -89,7 +89,7 @@ export class Connection {
             return {}
         }
 
-        const parser = new Parser();
+            const parser = new Parser({explicitArray : false});
 
         try {
             return await parser.parseStringPromise(xml)


### PR DESCRIPTION
Now the answer is :
```
{
  response: {
    LocalUnread: '4',
    LocalInbox: '4',
    LocalOutbox: '6',
    LocalDraft: '1',
    LocalDeleted: '0',
    SimUnread: '0',
    SimInbox: '0',
    SimOutbox: '0',
    SimDraft: '0',
    LocalMax: '500',
    SimMax: '20',
    SimUsed: '0',
    NewMsg: '0'
  }
}

```