### PR TITLE
Fixed the SMS send API (error 100005)

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -73,7 +73,7 @@ export class Connection {
         /* Force empty tags instead of selfclosing tags */
         const builder = new Builder(<any>{
             renderOpts: {
-                pretty: true,
+                pretty: false,
                 indent: ' ',
                 newline: '\n',
                 allowEmpty: true


### PR DESCRIPTION
This PR improves issue https://github.com/Salamek/huawei-lte-api-ts/issues/15. The `100005` error is `ERROR_FORMAT_ERROR`.

The web interface sends it this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<request>
  <Index>-1</Index>
  <Phones>
    <Phone>+00001111111</Phone>
  </Phones>
  <Sca></Sca>
  <Content>Hello World!</Content>
  <Length>12</Length>
  <Reserved>1</Reserved>
  <Date>2021-12-29 02:11:51</Date>
</request>
```

The Node.js sends it this:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<request>
  <Index>-1</Index>
  <Phones>
    <Phone>+00001111111</Phone>
  </Phones>
  <Sca/>
  <Content>Hello World!</Content>
  <Length>12</Length>
  <Reserved>1</Reserved>
  <Date>2021-12-29 01:18:22</Date>
</request>
```

The standalone root parameter and -1 hour doesn't affect, but the "pretty" format yes. If I set `false` the SMS is sent out.