### PR TITLE
WIP: Adding `AxiosRequestConfig` to the constructor of connection.

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -3,7 +3,7 @@ import { ResponseCodeEnum } from './enums/client';
 import { Session } from './Session';
 import { Parser, Builder } from "xml2js";
 import { join } from 'path';
-import { AxiosResponse } from 'axios';
+import { AxiosResponse, AxiosRequestConfig } from 'axios';
 import * as FormData from 'form-data';
 import { GetResponseType, SetResponseType } from './types'
 
@@ -35,8 +35,8 @@ export class Connection {
     session: Session;
     ready: Promise<void>;
 
-    constructor(url: string, timeout: number) {
-        this.session = new Session(timeout);
+    constructor(url: string, axios_config: AxiosRequestConfig) {
+        this.session = new Session(axios_config);
 
         if (!url.endsWith('/')) {
             url += '/';

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -10,11 +10,11 @@ export class Session {
     cookieJar: tough.CookieJar;
 
 
-    constructor(timeout: number) {
+    constructor(axios_config: AxiosRequestConfig) {
         const cookieStore = new tough.MemoryCookieStore();
         this.cookieJar = new tough.CookieJar(cookieStore);
         this.axiosInstance = wrapper(axios.create({
-            timeout: timeout,
+            ...axios_config,
             jar: this.cookieJar,
             withCredentials: true
         }));


### PR DESCRIPTION
As i said in #23 there are limitations with nodejs with managing multiple dongles at once (as far as i understood) and as a workaround a proxy could be used to limit routes to single dongle.

Now, accessing `connection.session.axiosInstance` to set the proxy after constructing the connection is too late and will result in `100003: No rights (needs login)`, hence we need a way to pass the proxy before connection gets initiated.

I thought it might be useful to pass `AxiosRequestConfig` instead of `timeout` in constructor parameters, which is essentially a member of the same object.

But as a result, it will create breaking change and need bump on the version, and it might not be something you're up to.

Hence i created this PR to get your opinion on how we can proceed, here are the possibilities:

1- We can keep the `timeout` and add `axios_config` as an optional third parameter.
2- We can go as it is and probably bump the version.
3- We can get `proxy` as the third parameter and avoid dealing with `AxiosRequestConfig` (my least favorite option)

I'm eager to hear your thoughts on this @Salamek.